### PR TITLE
feat: add weekly aggregation to overview charts

### DIFF
--- a/src/Theme/index.jsx
+++ b/src/Theme/index.jsx
@@ -57,14 +57,14 @@ const theme = (darkMode, color) => ({
   // borders
   bd1: darkMode ? '#464366' : '#464366',
 
-  //specialty colors
+  // specialty colors
   dropdownBg: darkMode ? 'rgba(104, 110, 148, 0.2)' : '',
   modalBG: darkMode ? 'rgba(0,0,0,0.85)' : 'rgba(0,0,0,0.6)',
   advancedBG: darkMode ? 'rgba(0,0,0,0.1)' : 'rgba(255,255,255,0.4)',
   onlyLight: darkMode ? '#22242a' : 'transparent',
   divider: darkMode ? 'rgba(43, 43, 43, 0.435)' : 'rgba(43, 43, 43, 0.035)',
 
-  //primary colors
+  // primary colors
   primary1: darkMode ? '#0D47A1' : '#2962FF',
   primary2: darkMode ? '#1976D2' : '#82B1FF',
   primary3: darkMode ? '#1E88E5' : '#438AFF',

--- a/src/components/Chart/CrosshairTooltip/index.jsx
+++ b/src/components/Chart/CrosshairTooltip/index.jsx
@@ -1,22 +1,19 @@
-import dayjs from 'dayjs';
 import PropTypes from 'prop-types';
 import { useMedia } from 'react-use';
 
 import { Typography } from '../../../Theme';
-import { formatChartValueByType, getWeekFormattedDate } from '../../../utils';
+import { formatChartDate, formatChartValueByType } from '../../../utils';
 import { Wrapper } from './styled';
 
 const CrosshairTooltip = ({ title, active, isWeeklyActive, payload, dataType }) => {
-  const below500 = useMedia('(max-width: 500px)');
+  const isBelow500 = useMedia('(max-width: 500px)');
 
   if (active && payload && payload.length) {
     const { time, value } = payload[0].payload;
 
     return (
       <Wrapper>
-        <Typography.Text color={'text10'}>
-          {isWeeklyActive ? getWeekFormattedDate(time, below500) : dayjs(time).format('MMMM D, YYYY')}
-        </Typography.Text>
+        <Typography.Text color={'text10'}>{formatChartDate(time, isWeeklyActive, isBelow500)}</Typography.Text>
         <Typography.Text color={'text10'}>{title}</Typography.Text>
         <Typography.Text color={'text10'}>{formatChartValueByType(value, dataType)}</Typography.Text>
       </Wrapper>

--- a/src/components/Chart/CrosshairTooltip/index.jsx
+++ b/src/components/Chart/CrosshairTooltip/index.jsx
@@ -6,14 +6,14 @@ import { formatChartDate, formatChartValueByType } from '../../../utils';
 import { Wrapper } from './styled';
 
 const CrosshairTooltip = ({ title, active, isWeeklyActive, payload, dataType }) => {
-  const isBelow500 = useMedia('(max-width: 500px)');
+  const isBelow500px = useMedia('(max-width: 500px)');
 
   if (active && payload && payload.length) {
     const { time, value } = payload[0].payload;
 
     return (
       <Wrapper>
-        <Typography.Text color={'text10'}>{formatChartDate(time, isWeeklyActive, isBelow500)}</Typography.Text>
+        <Typography.Text color={'text10'}>{formatChartDate(time, isWeeklyActive, isBelow500px)}</Typography.Text>
         <Typography.Text color={'text10'}>{title}</Typography.Text>
         <Typography.Text color={'text10'}>{formatChartValueByType(value, dataType)}</Typography.Text>
       </Wrapper>

--- a/src/components/Chart/CrosshairTooltip/index.jsx
+++ b/src/components/Chart/CrosshairTooltip/index.jsx
@@ -1,17 +1,22 @@
 import dayjs from 'dayjs';
 import PropTypes from 'prop-types';
+import { useMedia } from 'react-use';
 
 import { Typography } from '../../../Theme';
-import { formatChartValueByType } from '../../../utils';
+import { formatChartValueByType, getWeekFormattedDate } from '../../../utils';
 import { Wrapper } from './styled';
 
-const CrosshairTooltip = ({ title, active, payload, dataType }) => {
+const CrosshairTooltip = ({ title, active, isWeeklyActive, payload, dataType }) => {
+  const below500 = useMedia('(max-width: 500px)');
+
   if (active && payload && payload.length) {
     const { time, value } = payload[0].payload;
 
     return (
       <Wrapper>
-        <Typography.Text color={'text10'}>{dayjs(time).format('MMMM D, YYYY')}</Typography.Text>
+        <Typography.Text color={'text10'}>
+          {isWeeklyActive ? getWeekFormattedDate(time, below500) : dayjs(time).format('MMMM D, YYYY')}
+        </Typography.Text>
         <Typography.Text color={'text10'}>{title}</Typography.Text>
         <Typography.Text color={'text10'}>{formatChartValueByType(value, dataType)}</Typography.Text>
       </Wrapper>
@@ -24,6 +29,7 @@ const CrosshairTooltip = ({ title, active, payload, dataType }) => {
 CrosshairTooltip.propTypes = {
   title: PropTypes.string,
   active: PropTypes.bool,
+  isWeeklyActive: PropTypes.bool,
   payload: PropTypes.array,
   dataType: PropTypes.oneOf(['CURRENCY', 'PERCENTAGE']),
 };

--- a/src/components/Chart/Header/index.jsx
+++ b/src/components/Chart/Header/index.jsx
@@ -1,9 +1,12 @@
 import PropTypes from 'prop-types';
+import { useMedia } from 'react-use';
+import { Flex } from 'rebass';
 
 import { Typography } from '../../../Theme';
+import { TIME_FILTER_OPTIONS } from '../../../constants';
 import { formatChartValueByType } from '../../../utils';
 import RadioTimeFilter from '../../RadioTimeFilter';
-import { Container, DailyChange, FlexContainer } from './styled';
+import { Container, DailyChange, FlexContainer, WeeklyButton } from './styled';
 
 const Header = ({
   title,
@@ -13,30 +16,40 @@ const Header = ({
   date,
   filterOptions,
   activeFilter,
+  isWeeklyActive,
   onFilterChange,
+  onWeeklyToggle,
   showTimeFilter,
-}) => (
-  <Container>
-    <div>
-      <Typography.LargeBoldText color={'text7'} sx={{ textTransform: 'uppercase', marginBottom: '4px' }}>
-        {title}
-      </Typography.LargeBoldText>
-      <Typography.LargeBoldHeader sx={{ marginRight: 10, marginBottom: '4px' }}>
-        {formatChartValueByType(value, dataType)}
-      </Typography.LargeBoldHeader>
-      <FlexContainer>
-        <Typography.Text color={'text7'}>{date}</Typography.Text>
-        <DailyChange>{dailyChange}</DailyChange>
-      </FlexContainer>
-    </div>
-    {showTimeFilter && (
-      <div>
-        <RadioTimeFilter options={filterOptions} activeValue={activeFilter} onChange={onFilterChange} />
-      </div>
-    )}
-  </Container>
-);
+}) => {
+  const below500 = useMedia('(max-width: 500px)');
 
+  return (
+    <Container>
+      <div>
+        <Typography.LargeBoldText color={'text7'} sx={{ textTransform: 'uppercase', marginBottom: '4px' }}>
+          {title}
+        </Typography.LargeBoldText>
+        <Typography.LargeBoldHeader sx={{ marginRight: 10, marginBottom: '4px' }}>
+          {formatChartValueByType(value, dataType, below500)}
+        </Typography.LargeBoldHeader>
+        <FlexContainer alignItems={'center'} flexDirection={'row'}>
+          <Typography.Text color={'text7'}>{date}</Typography.Text>
+          <DailyChange>{dailyChange}</DailyChange>
+        </FlexContainer>
+      </div>
+      {showTimeFilter && (
+        <Flex flexDirection={'column'} alignItems={'flex-end'} style={{ gap: '6px' }}>
+          <RadioTimeFilter options={filterOptions} activeValue={activeFilter} onChange={onFilterChange} />
+          {activeFilter !== TIME_FILTER_OPTIONS.WEEK && (
+            <WeeklyButton onClick={onWeeklyToggle} isActive={isWeeklyActive}>
+              <Typography.Text>BY WEEK</Typography.Text>
+            </WeeklyButton>
+          )}
+        </Flex>
+      )}
+    </Container>
+  );
+};
 Header.propTypes = {
   title: PropTypes.string,
   dailyChange: PropTypes.any,
@@ -46,7 +59,9 @@ Header.propTypes = {
   filterOptions: PropTypes.object,
   activeFilter: PropTypes.string,
   onFilterChange: PropTypes.func.isRequired,
+  onWeeklyToggle: PropTypes.func.isRequired,
   showTimeFilter: PropTypes.bool,
+  isWeeklyActive: PropTypes.bool,
 };
 
 Header.defaultProps = {

--- a/src/components/Chart/Header/index.jsx
+++ b/src/components/Chart/Header/index.jsx
@@ -21,7 +21,7 @@ const Header = ({
   onWeeklyToggle,
   showTimeFilter,
 }) => {
-  const isBelow500 = useMedia('(max-width: 500px)');
+  const isBelow500px = useMedia('(max-width: 500px)');
 
   return (
     <Container>
@@ -30,10 +30,10 @@ const Header = ({
           {title}
         </Typography.LargeBoldText>
         <Typography.LargeBoldHeader sx={{ marginRight: 10, marginBottom: '4px' }}>
-          {formatChartValueByType(value, dataType, isBelow500)}
+          {formatChartValueByType(value, dataType, isBelow500px)}
         </Typography.LargeBoldHeader>
         <FlexContainer alignItems={'center'} flexDirection={'row'}>
-          <Typography.Text color={'text7'}>{formatChartDate(date, isWeeklyActive, isBelow500)}</Typography.Text>
+          <Typography.Text color={'text7'}>{formatChartDate(date, isWeeklyActive, isBelow500px)}</Typography.Text>
           <DailyChange>{dailyChange}</DailyChange>
         </FlexContainer>
       </div>

--- a/src/components/Chart/Header/index.jsx
+++ b/src/components/Chart/Header/index.jsx
@@ -4,7 +4,7 @@ import { Flex } from 'rebass';
 
 import { Typography } from '../../../Theme';
 import { TIME_FILTER_OPTIONS } from '../../../constants';
-import { formatChartValueByType } from '../../../utils';
+import { formatChartDate, formatChartValueByType } from '../../../utils';
 import RadioTimeFilter from '../../RadioTimeFilter';
 import { Container, DailyChange, FlexContainer, WeeklyButton } from './styled';
 
@@ -21,7 +21,7 @@ const Header = ({
   onWeeklyToggle,
   showTimeFilter,
 }) => {
-  const below500 = useMedia('(max-width: 500px)');
+  const isBelow500 = useMedia('(max-width: 500px)');
 
   return (
     <Container>
@@ -30,10 +30,10 @@ const Header = ({
           {title}
         </Typography.LargeBoldText>
         <Typography.LargeBoldHeader sx={{ marginRight: 10, marginBottom: '4px' }}>
-          {formatChartValueByType(value, dataType, below500)}
+          {formatChartValueByType(value, dataType, isBelow500)}
         </Typography.LargeBoldHeader>
         <FlexContainer alignItems={'center'} flexDirection={'row'}>
-          <Typography.Text color={'text7'}>{date}</Typography.Text>
+          <Typography.Text color={'text7'}>{formatChartDate(date, isWeeklyActive, isBelow500)}</Typography.Text>
           <DailyChange>{dailyChange}</DailyChange>
         </FlexContainer>
       </div>

--- a/src/components/Chart/Header/styled.jsx
+++ b/src/components/Chart/Header/styled.jsx
@@ -1,3 +1,4 @@
+import { Flex } from 'rebass';
 import styled from 'styled-components';
 
 const Container = styled.div`
@@ -6,10 +7,8 @@ const Container = styled.div`
   color: white;
 `;
 
-const FlexContainer = styled.div`
-  display: flex;
+const FlexContainer = styled(Flex)`
   gap: 6px;
-  align-items: center;
 `;
 
 const DailyChange = styled.div`
@@ -18,4 +17,27 @@ const DailyChange = styled.div`
   }
 `;
 
-export { Container, FlexContainer, DailyChange };
+const WeeklyButton = styled.button`
+  height: 26px;
+  padding: 4px 5px;
+  border: 1px solid;
+  border-color: ${({ theme }) => theme.bd1};
+  border-radius: 6px;
+  background-color: ${({ isActive, theme }) => (isActive ? theme.bg2 : 'transparent')};
+
+  :hover {
+    cursor: pointer;
+  }
+
+  :hover > * {
+    color: ${({ theme }) => theme.text12};
+  }
+
+  & > div {
+    color: ${({ isActive, theme }) => (isActive ? theme.text12 : theme.text7)};
+  }
+
+  transition: background 200ms;
+`;
+
+export { Container, FlexContainer, DailyChange, WeeklyButton };

--- a/src/components/Chart/index.jsx
+++ b/src/components/Chart/index.jsx
@@ -80,12 +80,23 @@ const Chart = ({ title, tooltipTitle, data, type, dataType, overridingActiveFilt
       let pastHeaderValue = 0;
       let currentHeaderValue = 0;
 
-      Object.keys(data[data.length - 1])
-        .filter((key) => key !== 'time')
-        .forEach((key) => {
-          currentHeaderValue += data[data.length - 1][key];
-          pastHeaderValue += data[data.length - 2][key];
-        });
+      if (isWeeklyActive) {
+        const weeklyAggregatedData = getWeeklyAggregatedData(getFilterLimitDate(activeFilter), data);
+
+        Object.keys(weeklyAggregatedData[weeklyAggregatedData.length - 1])
+          .filter((key) => key !== 'time')
+          .forEach((key) => {
+            currentHeaderValue += weeklyAggregatedData[weeklyAggregatedData.length - 1][key];
+            pastHeaderValue += weeklyAggregatedData[weeklyAggregatedData.length - 2][key];
+          });
+      } else {
+        Object.keys(data[data.length - 1])
+          .filter((key) => key !== 'time')
+          .forEach((key) => {
+            currentHeaderValue += data[data.length - 1][key];
+            pastHeaderValue += data[data.length - 2][key];
+          });
+      }
 
       const dailyChange = pastHeaderValue > 0 ? ((currentHeaderValue - pastHeaderValue) / pastHeaderValue) * 100 : 0;
 
@@ -93,7 +104,7 @@ const Chart = ({ title, tooltipTitle, data, type, dataType, overridingActiveFilt
       setActiveDate(data[data.length - 1].time);
       setHeaderValue(currentHeaderValue);
     }
-  }, [data]);
+  }, [data, activeFilter, isWeeklyActive]);
 
   // set header values to the current point of the chart
   const setCurrentHeaderValues = (params) => {

--- a/src/components/Chart/index.jsx
+++ b/src/components/Chart/index.jsx
@@ -2,12 +2,11 @@ import dayjs from 'dayjs';
 import isoWeek from 'dayjs/plugin/isoWeek';
 import PropTypes from 'prop-types';
 import { useCallback, useEffect, useState } from 'react';
-import { useMedia } from 'react-use';
 import { Area, AreaChart, Bar, ComposedChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 import { useTheme } from 'styled-components';
 
 import { TIME_FILTER_OPTIONS } from '../../constants';
-import { formattedPercent, getWeekFormattedDate } from '../../utils';
+import { formattedPercent } from '../../utils';
 import CrosshairTooltip from './CrosshairTooltip';
 import Header from './Header';
 
@@ -76,8 +75,6 @@ const Chart = ({ title, tooltipTitle, data, type, dataType, overridingActiveFilt
   const [activeFilter, setActiveFilter] = useState(TIME_FILTER_OPTIONS.MONTH_1);
   const [dailyChange, setDailyChange] = useState();
   const [isWeeklyActive, setIsWeeklyActive] = useState(false);
-
-  const below500 = useMedia('(max-width: 500px)');
 
   // set header values to the latest point of the chart
   const setDefaultHeaderValues = useCallback(() => {
@@ -185,7 +182,7 @@ const Chart = ({ title, tooltipTitle, data, type, dataType, overridingActiveFilt
         dataType={dataType}
         showTimeFilter={showTimeFilter}
         dailyChange={formattedPercent(dailyChange)}
-        date={isWeeklyActive ? getWeekFormattedDate(activeDate, below500) : dayjs(activeDate).format('MMMM D, YYYY')}
+        date={activeDate}
         activeFilter={activeFilter}
         isWeeklyActive={isWeeklyActive}
         filterOptions={TIME_FILTER_OPTIONS}

--- a/src/components/Chart/index.jsx
+++ b/src/components/Chart/index.jsx
@@ -44,7 +44,7 @@ const getWeeklyAggregatedData = (limitDate, data) => {
       const weekStart = dayjs(current.time).startOf('week');
       const weekEnd = dayjs(current.time).endOf('week');
 
-      const weekId = `${dayjs(current.time).year()}-${weekStart.unix()}-${weekEnd.unix()}`;
+      const weekId = `${weekStart.year()}-${weekStart.unix()}-${weekEnd.year()}-${weekEnd.unix()}`;
 
       return {
         ...previous,

--- a/src/utils/index.jsx
+++ b/src/utils/index.jsx
@@ -451,11 +451,13 @@ export const formatNumber = (num) => {
 };
 
 // using a currency library here in case we want to add more in future
-export const formatDollarAmount = (num, digits) => {
+export const formatDollarAmount = (num, digits, short) => {
   const formatter = new Intl.NumberFormat([], {
     style: 'currency',
     currency: 'USD',
     currencyDisplay: 'symbol',
+    notation: short ? 'compact' : 'standard',
+    compactDisplay: short ? 'short' : 'long',
     minimumFractionDigits: digits,
     maximumFractionDigits: digits,
   });
@@ -803,4 +805,8 @@ export function getWeekFormattedDate(date, short) {
     .isoWeekday(6)
     .set('year', dayjs(date).year())
     .format(short ? 'MMM D, YY' : 'MMMM D, YYYY')}`;
+}
+
+export function formatChartDate(date, isWeekly, short) {
+  return isWeekly ? getWeekFormattedDate(date, short) : dayjs(date).format(short ? 'MMM D, YY' : 'MMMM D, YYYY');
 }

--- a/src/utils/index.jsx
+++ b/src/utils/index.jsx
@@ -791,12 +791,16 @@ export function formatChartValueByType(value, dataType, short) {
  * @returns
  */
 export function getWeekFormattedDate(date, short) {
-  const fromWeek = dayjs(date).isoWeek();
-  const toWeek = dayjs(date).isoWeek() + 1;
+  const fromWeek = dayjs(date).isoWeekday(7).isoWeek();
+  const toWeek = dayjs(date).isoWeekday(6).isoWeek() + 1;
 
   return `${dayjs()
     .isoWeek(fromWeek)
+    .isoWeekday(7)
+    .set('year', dayjs(date).year())
     .format(short ? 'MMM D, YY' : 'MMMM D, YYYY')} - ${dayjs()
     .isoWeek(toWeek)
+    .isoWeekday(6)
+    .set('year', dayjs(date).year())
     .format(short ? 'MMM D, YY' : 'MMMM D, YYYY')}`;
 }

--- a/src/utils/index.jsx
+++ b/src/utils/index.jsx
@@ -773,9 +773,9 @@ export function formatCountDownString(timestamp) {
  * @param {*} value
  * @param {*} dataType CURRENCY | PERCENTAGE
  */
-export function formatChartValueByType(value, dataType) {
+export function formatChartValueByType(value, dataType, short) {
   if (dataType === 'CURRENCY') {
-    return formattedNum(value, true);
+    return formatDollarAmount(value, short ? 2 : 0, short);
   }
 
   if (dataType === 'PERCENTAGE') {
@@ -783,4 +783,20 @@ export function formatChartValueByType(value, dataType) {
   }
 
   return value;
+}
+
+/**
+ * Get date week range from a date
+ * @param {*} date
+ * @returns
+ */
+export function getWeekFormattedDate(date, short) {
+  const fromWeek = dayjs(date).isoWeek();
+  const toWeek = dayjs(date).isoWeek() + 1;
+
+  return `${dayjs()
+    .isoWeek(fromWeek)
+    .format(short ? 'MMM D, YY' : 'MMMM D, YYYY')} - ${dayjs()
+    .isoWeek(toWeek)
+    .format(short ? 'MMM D, YY' : 'MMMM D, YYYY')}`;
 }


### PR DESCRIPTION
# Summary

Fixes #106 

Add the option to aggregate the charts on the `overview` page by week.
The `BY WEEK` button is enabled only when the active time filter is `1M` or `1Y`, and it's automatically disabled when the time filter is `1W`.

![image](https://user-images.githubusercontent.com/9011637/191112949-4d34e8da-dd57-4662-8eb5-e8fb27dbb750.png)
![image](https://user-images.githubusercontent.com/9011637/191113637-eccdc9b9-b6f1-42e7-b33a-08cda0fb66a6.png)

[scrnli_9_19_2022_11-16-42 PM.webm](https://user-images.githubusercontent.com/9011637/191119147-88ccc04e-c9ac-4237-a759-05f4c5015015.webm)

# How To Test
1.  Open the page `Overview`
- [ ] Verify the `By week` button correctly aggregates the chart data.