### PR TITLE
fix: replace old gnosis fee receiver

### DIFF
--- a/src/constants/index.tsx
+++ b/src/constants/index.tsx
@@ -142,7 +142,7 @@ export const MULTICALL_ADDRESS = {
 };
 
 export const NETOWRK_FEE_RECEIVER_ADDRESSES = {
-  [Networks.XDAI]: '0x65f29020d07a6cfa3b0bf63d749934d5a6e6ea18',
+  [Networks.XDAI]: '0xa68fad1e05a644414f4878ce5c5357be634bcf4c',
   [Networks.MAINNET]: '0xc6130400c1e3cd7b352db75055db9dd554e00ef0',
   [Networks.ARBITRUM_ONE]: '0x1d7c7cb66fb2d75123351fd0d6779e8d7724a1ae',
 };


### PR DESCRIPTION
Fix #108.

Replace the old fee receiver address for Gnosis chain.