### PR TITLE
feat: differentiate dxdao created campaigns

### DIFF
--- a/src/apollo/queries.js
+++ b/src/apollo/queries.js
@@ -766,6 +766,7 @@ export const LIQUIDITY_MINING_CAMPAIGNS_FOR_PAIR = graphql`
   query liquidityMiningCampaigns($endTimestamp: Int!, $pairAddress: Bytes!) {
     liquidityMiningCampaigns(first: 20, where: { endsAt_gte: $endTimestamp, stakablePair_: { id: $pairAddress } }) {
       id
+      owner
       startsAt
       endsAt
       locked
@@ -808,6 +809,7 @@ export const LIQUIDITY_MINING_CAMPAIGN_BY_ID = graphql`
   query liquidityMiningCampaigns($id: ID!) {
     liquidityMiningCampaigns(first: 1, where: { id: $id }) {
       id
+      owner
       startsAt
       endsAt
       locked
@@ -884,6 +886,7 @@ export const liquidityMiningCampaignsQuery = (status = 'active', currentTime) =>
     query liquidityMiningCampaigns {
       liquidityMiningCampaigns(where: { ${endsAtP}: ${currentTime} }) {
         id
+        owner
         stakedAmount
         startsAt
         endsAt

--- a/src/components/FarmingList/ListItem.jsx
+++ b/src/components/FarmingList/ListItem.jsx
@@ -10,7 +10,7 @@ import { Typography } from '../../Theme';
 import carrotListLogoUrl from '../../assets/images/carrot.png';
 import { CARROT_REWARD_TOKEN_REGEX, ChainId } from '../../constants';
 import { useNativeCurrencySymbol, useNativeCurrencyWrapper, useSelectedNetwork } from '../../contexts/Network';
-import { formatDollarAmount, formattedNum, getSwaprLink } from '../../utils';
+import { formatDollarAmount, formattedNum, getSwaprLink, isDxDaoCampaignOwner } from '../../utils';
 import DoubleTokenLogo from '../DoubleLogo';
 import FormattedName from '../FormattedName';
 import Link, { InternalListLink } from '../Link';
@@ -52,8 +52,8 @@ export const DashGrid = styled.div`
   @media screen and (min-width: 1081px) {
     display: grid;
     grid-gap: 0.5em;
-    grid-template-columns: 0.2fr 1fr 1fr 1fr 1fr 1fr 0.5fr;
-    grid-template-areas: 'index pair tvl yield apy rewardTokens link';
+    grid-template-columns: 0.2fr 1fr 1fr 1fr 1fr 1fr 0.5fr 0.5fr;
+    grid-template-areas: 'index pair tvl yield apy rewardTokens owner link';
   }
 `;
 
@@ -166,6 +166,11 @@ export default function ListItem({ campaign, index, nativeCurrencyPrice }) {
             );
           })}
         </Flex>
+        {!below1080 && (
+          <Flex area={'owner'} justifyContent={'center'}>
+            <FlexText>{isDxDaoCampaignOwner(campaign.owner) ? 'DXdao' : 'Other'}</FlexText>
+          </Flex>
+        )}
         <FlexText area="link">
           <Link
             color={'text8'}

--- a/src/components/FarmingList/index.jsx
+++ b/src/components/FarmingList/index.jsx
@@ -171,6 +171,13 @@ function FarmingList({ campaigns, disbaleLinks, maxItems = 10 }) {
               REWARD
             </Typography.SmallBoldText>
           </Flex>
+          {!below1080 && (
+            <Flex alignItems={'owner'} justifyContent={'center'}>
+              <Typography.SmallBoldText color={'text8'} sx={{ textTransform: 'uppercase' }}>
+                OWNER
+              </Typography.SmallBoldText>
+            </Flex>
+          )}
           <Flex alignItems={'center'} justifyContent={'flex-end'}>
             <Typography.SmallBoldText color={'text8'} sx={{ textTransform: 'uppercase' }}>
               LINK

--- a/src/components/PairCard/index.jsx
+++ b/src/components/PairCard/index.jsx
@@ -13,9 +13,9 @@ import { Wrapper } from './styled';
 
 const PairCard = ({ pairAddress, token0, token1, tvl, liquidityMiningCampaigns }) => {
   const isFarming = liquidityMiningCampaigns.find((campaign) => campaign.endsAt >= dayjs.utc().unix());
-  const hasCarrotRewards = liquidityMiningCampaigns.find((campaign) =>
-    campaign.rewards.find((reward) => CARROT_REWARD_TOKEN_REGEX.test(reward.token.symbol)),
-  );
+  const hasCarrotRewards = liquidityMiningCampaigns
+    .filter((campaign) => campaign.endsAt >= dayjs.utc().unix())
+    .find((campaign) => campaign.rewards.find((reward) => CARROT_REWARD_TOKEN_REGEX.test(reward.token.symbol)));
 
   return (
     <InternalListLink to={'/pair/' + pairAddress}>

--- a/src/constants/index.tsx
+++ b/src/constants/index.tsx
@@ -167,6 +167,10 @@ export const NETWORK_COLORS = {
   [SupportedNetwork.ARBITRUM_ONE]: '#685EC6',
 };
 
+export const MULTI_CHAIN_MULTI_SIG = '0x9467dcfd4519287e3878c018c02f5670465a9003';
+
+export const SWAPR_WALLET = '0x3172edda6ff8b2b2fa7fed40ee1fd92f1f4dd424';
+
 export const SWAPR_LINK = 'https://swapr.eth.limo/#';
 
 export const CARROT_LINK = 'https://carrot.eth.limo/#';

--- a/src/pages/FarmPage.jsx
+++ b/src/pages/FarmPage.jsx
@@ -11,11 +11,13 @@ import { USD } from '@swapr/sdk';
 
 import { Typography } from '../Theme';
 import carrotListLogoUrl from '../assets/images/carrot.png';
+import { ReactComponent as DxdLogoSvg } from '../assets/svg/dxd-logo.svg';
 import { ContentWrapper, PageWrapper } from '../components';
 import { ButtonDark, ButtonLight } from '../components/ButtonStyled';
 import DoubleTokenLogo from '../components/DoubleLogo';
 import GoToCampaignLink from '../components/GoToCampaignLink';
 import { Grid } from '../components/Grid';
+import Icon from '../components/Icon';
 import LabeledValue from '../components/LabeledValue';
 import Link, { BasicLink, ExternalListLink } from '../components/Link';
 import LiquidityMiningCampaignCardList from '../components/LiquidityMiningCampaignCardList';
@@ -26,7 +28,7 @@ import { CARROT_REWARD_TOKEN_REGEX, ChainId } from '../constants';
 import { useNativeCurrencyPrice } from '../contexts/GlobalData';
 import { useNativeCurrencySymbol, useNativeCurrencyWrapper, useSelectedNetwork } from '../contexts/Network';
 import { useLiquidityMiningCampaignData, useLiquidityMiningCampaignsForPair, usePairData } from '../contexts/PairData';
-import { formatDollarAmount, getExplorerLink, getSwapLink, getSwaprLink } from '../utils';
+import { formatDollarAmount, getExplorerLink, getSwapLink, getSwaprLink, isDxDaoCampaignOwner } from '../utils';
 
 const DashboardWrapper = styled.div`
   width: 100%;
@@ -373,6 +375,21 @@ const FarmPage = ({ campaignAddress, pairAddress }) => {
                 )}
               </Flex>
             </Panel>
+            {campaign && isDxDaoCampaignOwner(campaign.owner) && (
+              <Panel height={'fit-content'} width={isBelow600px ? '100%' : 'fit-content'}>
+                <Flex flexDirection={'column'} style={{ gap: '28px' }}>
+                  <Typography.Custom sx={{ fontWeight: 500, fontSize: '16px', lineHeight: '19px' }}>
+                    Owner
+                  </Typography.Custom>
+                  <Flex alignItems={'center'} style={{ gap: '16px' }}>
+                    <Icon marginRight={'0'} icon={<DxdLogoSvg height={24} width={24} />} />
+                    <Typography.LargeBoldText color={'text6'} sx={{ letterSpacing: '0.02em' }}>
+                      Campaign created by DXdao
+                    </Typography.LargeBoldText>
+                  </Flex>
+                </Flex>
+              </Panel>
+            )}
           </PanelWrapper>
           <LiquidityMiningCampaignCardList
             campaigns={liquidityMiningCampaigns}

--- a/src/pages/FarmPage.jsx
+++ b/src/pages/FarmPage.jsx
@@ -328,24 +328,24 @@ const FarmPage = ({ campaignAddress, pairAddress }) => {
                 </Flex>
               </Flex>
             </Panel>
-            <Panel style={{ height: '100%' }}>
-              <Flex flexDirection={'column'} style={{ gap: '28px' }}>
-                <Typography.Custom sx={{ fontWeight: 500, fontSize: '16px', lineHeight: '19px' }}>
-                  Carrot campaigns
-                </Typography.Custom>
-                <Flex flexDirection={'column'} style={{ gap: '16px' }}>
-                  <Typography.Text color={'text6'} sx={{ letterSpacing: '0.02em' }}>
-                    Learn how to use KPI tokens through Carrot by clicking{' '}
-                    <Link
-                      color={'text7'}
-                      external={true}
-                      href={'https://medium.com/carrot-eth/how-to-use-carrot-374e0e1abbe2'}
-                    >
-                      here
-                    </Link>
-                    .
-                  </Typography.Text>
-                  {campaign && campaign.kpiRewards.length > 0 && (
+            {campaign && campaign.kpiRewards.length > 0 && (
+              <Panel style={{ height: '100%' }}>
+                <Flex flexDirection={'column'} style={{ gap: '28px' }}>
+                  <Typography.Custom sx={{ fontWeight: 500, fontSize: '16px', lineHeight: '19px' }}>
+                    Carrot campaigns
+                  </Typography.Custom>
+                  <Flex flexDirection={'column'} style={{ gap: '16px' }}>
+                    <Typography.Text color={'text6'} sx={{ letterSpacing: '0.02em' }}>
+                      Learn how to use KPI tokens through Carrot by clicking{' '}
+                      <Link
+                        color={'text7'}
+                        external={true}
+                        href={'https://medium.com/carrot-eth/how-to-use-carrot-374e0e1abbe2'}
+                      >
+                        here
+                      </Link>
+                      .
+                    </Typography.Text>
                     <>
                       <Typography.Text color={'text6'} sx={{ letterSpacing: '0.02em' }}>
                         This campaign contains Carrot KPI tokens that are redeemable for collateral upon reaching the
@@ -365,16 +365,11 @@ const FarmPage = ({ campaignAddress, pairAddress }) => {
                         </Flex>
                       ))}
                     </>
-                  )}
+                  </Flex>
+                  {!campaign && <Skeleton height={'32px'} witdh={'120px'} />}
                 </Flex>
-                {!campaign && <Skeleton height={'32px'} witdh={'120px'} />}
-                {campaign && campaign.kpiRewards.length === 0 && (
-                  <Typography.Text color={'text6'} sx={{ letterSpacing: '0.02em' }}>
-                    There are no active Carrot campaings linked to this farm.
-                  </Typography.Text>
-                )}
-              </Flex>
-            </Panel>
+              </Panel>
+            )}
             {campaign && isDxDaoCampaignOwner(campaign.owner) && (
               <Panel height={'fit-content'} width={isBelow600px ? '100%' : 'fit-content'}>
                 <Flex flexDirection={'column'} style={{ gap: '28px' }}>

--- a/src/utils/index.jsx
+++ b/src/utils/index.jsx
@@ -30,7 +30,16 @@ import {
   PRICES_BY_BLOCK,
   SHARE_VALUE,
 } from '../apollo/queries';
-import { SupportedNetwork, timeframeOptions, ETHERSCAN_PREFIXES, ChainId, SWAPR_LINK, CARROT_LINK } from '../constants';
+import {
+  SupportedNetwork,
+  timeframeOptions,
+  ETHERSCAN_PREFIXES,
+  ChainId,
+  SWAPR_LINK,
+  CARROT_LINK,
+  SWAPR_WALLET,
+  MULTI_CHAIN_MULTI_SIG,
+} from '../constants';
 
 // format libraries
 const Decimal = toFormat(_Decimal);
@@ -731,6 +740,7 @@ export function toLiquidityMiningCampaign(
   // add APY related to the KPI rewards
   liquidityMiningCampaign.kpiApy = new Percent(rawApy.numerator, rawApy.denominator);
   liquidityMiningCampaign.kpiRewards = kpiRewards;
+  liquidityMiningCampaign.owner = campaign.owner;
 
   return liquidityMiningCampaign;
 }
@@ -839,4 +849,8 @@ export function getWeekFormattedDate(date, short) {
 
 export function formatChartDate(date, isWeekly, short) {
   return isWeekly ? getWeekFormattedDate(date, short) : dayjs(date).format(short ? 'MMM D, YY' : 'MMMM D, YYYY');
+}
+
+export function isDxDaoCampaignOwner(campaignOwner) {
+  return [SWAPR_WALLET, MULTI_CHAIN_MULTI_SIG].includes(campaignOwner);
 }


### PR DESCRIPTION
Fixes #60.

Add farm owner to the list as `DXdao` or `Other` and a panel indicating the owner in the details page (only if the campaign is created by the dao).

![image](https://user-images.githubusercontent.com/9011637/192887737-18221275-3384-48ed-afde-67fea0e375da.png)
![image](https://user-images.githubusercontent.com/9011637/192887847-d72c79aa-b531-44ed-bdc5-785bc35f241f.png)
