### PR TITLE
use new uncollected fees value for gnosis

### DIFF
--- a/src/contexts/Dashboard.jsx
+++ b/src/contexts/Dashboard.jsx
@@ -452,7 +452,7 @@ const getUncollectedFees = async () => {
     return {
       [SupportedNetwork.MAINNET]: uncollectedFees.mainnetUSD,
       [SupportedNetwork.ARBITRUM_ONE]: uncollectedFees.arbitrumOneUSD,
-      [SupportedNetwork.XDAI]: uncollectedFees.xDaiUSD,
+      [SupportedNetwork.XDAI]: uncollectedFees.gnosisUSD,
       total: uncollectedFees.totalUSD,
     };
   } catch (error) {


### PR DESCRIPTION
After the `uncollected-fees` service's update the returned value for the gnosis chain changed, these changes fix the issue.