### PR TITLE
optimize wallets charts, add new ones

### DIFF
--- a/src/apollo/queries.js
+++ b/src/apollo/queries.js
@@ -497,46 +497,56 @@ export const DASHBOARD_COMULATIVE_DATA = graphql`
 `;
 
 export const DASHBOARD_SWAPS_HISTORY_WITH_TIMESTAMP = graphql`
-  query swaps($lastId: ID!, $startTime: Int!) {
-    swaps(first: 1000, where: { id_gt: $lastId, timestamp_gt: $startTime }) {
+  query swaprDayDatas($startTime: Int!) {
+    swaprDayDatas(first: 1000, where: { date_gte: $startTime }) {
       id
-      timestamp
+      date
+      dailySwaps
     }
   }
 `;
 
-export const DASHBOARD_SWAPS_HISTORY = graphql`
-  query swaps($lastId: ID!, $startTime: Int!) {
-    swaps(first: 1000, where: { id_gt: $lastId, timestamp_gt: $startTime }) {
+export const DASHBOARD_UNIQUE_DAILY_INTERACTIONS = graphql`
+  query ($startTime: Int!) {
+    dailyUniqueAddressInteractions(
+      first: 1000
+      where: { timestamp_gte: $startTime }
+      orderBy: timestamp
+      orderDirection: asc
+    ) {
       id
+      timestamp
+      addresses
     }
   }
 `;
 
-export const DASHBOARD_MINTS_AND_SWAPS_WITH_TIMESTAMP = graphql`
-  query ($lastMintId: ID!, $lastSwapId: ID!, $startTime: Int!) {
-    mints(first: 1000, where: { id_gt: $lastMintId, timestamp_gt: $startTime }) {
+export const DASHBOARD_UNIQUE_WEEKLY_INTERACTIONS = graphql`
+  query ($startTime: Int!) {
+    weeklyUniqueAddressInteractions(
+      first: 1000
+      where: { timestampStart_gte: $startTime }
+      orderBy: timestampStart
+      orderDirection: asc
+    ) {
       id
-      to
-      timestamp
-    }
-    swaps(first: 1000, where: { id_gt: $lastSwapId, timestamp_gt: $startTime }) {
-      id
-      to
-      timestamp
+      timestampStart
+      addresses
     }
   }
 `;
 
-export const DASHBOARD_MINTS_AND_SWAPS = graphql`
-  query ($lastMintId: ID!, $lastSwapId: ID!, $startTime: Int!) {
-    mints(first: 1000, where: { id_gt: $lastMintId, timestamp_gt: $startTime }) {
+export const DASHBOARD_UNIQUE_MONTHLY_INTERACTIONS = graphql`
+  query ($startTime: Int!) {
+    monthlyUniqueAddressInteractions(
+      first: 1000
+      where: { timestamp_gte: $startTime }
+      orderBy: timestamp
+      orderDirection: asc
+    ) {
       id
-      to
-    }
-    swaps(first: 1000, where: { id_gt: $lastSwapId, timestamp_gt: $startTime }) {
-      id
-      to
+      timestamp
+      addresses
     }
   }
 `;

--- a/src/components/NetworkDataCardWithDialog/Dialog/index.tsx
+++ b/src/components/NetworkDataCardWithDialog/Dialog/index.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import LocalLoader from '../../LocalLoader';
 import StackedChart from '../../StackedChart';
-import { CloseChartIcon, StyledDialogContent, StyledDialogOverlay, Wrapper } from './styled';
+import { StyledDialogContent, StyledDialogOverlay, Wrapper } from './styled';
 
 const AnimatedDialogOverlay = animated(StyledDialogOverlay);
 const AnimatedDialogContent = animated(StyledDialogContent);
@@ -12,10 +12,21 @@ interface DialogWithChartProps {
   title: string;
   historicalDataHook: any;
   isOpen: boolean;
+  isTimeFilterVisible: boolean;
+  defaultTimeFilter: '1M' | '3M' | '1Y';
+  formatActiveDate: any;
   onClose: React.MouseEventHandler;
 }
 
-const DialogWithChart = ({ title, historicalDataHook, isOpen, onClose }: DialogWithChartProps) => {
+const DialogWithChart = ({
+  title,
+  historicalDataHook,
+  isOpen,
+  isTimeFilterVisible,
+  defaultTimeFilter = '1M',
+  formatActiveDate = null,
+  onClose,
+}: DialogWithChartProps) => {
   const data = historicalDataHook();
 
   const transitions = useTransition(isOpen, {
@@ -32,8 +43,15 @@ const DialogWithChart = ({ title, historicalDataHook, isOpen, onClose }: DialogW
           <AnimatedDialogContent aria-label={'trades'}>
             {data && data.length > 0 ? (
               <Wrapper>
-                <CloseChartIcon size={22} onClick={onClose} />
-                <StackedChart title={title} type={'AREA'} data={data} dataType={'BASE'} showTimeFilter={false} />
+                <StackedChart
+                  title={title}
+                  type={'AREA'}
+                  data={data}
+                  dataType={'BASE'}
+                  showTimeFilter={isTimeFilterVisible}
+                  formatActiveDate={formatActiveDate}
+                  defaultTimeFilter={defaultTimeFilter}
+                />
               </Wrapper>
             ) : (
               <LocalLoader fill={false} height={undefined} />

--- a/src/components/NetworkDataCardWithDialog/Dialog/styled.tsx
+++ b/src/components/NetworkDataCardWithDialog/Dialog/styled.tsx
@@ -1,18 +1,6 @@
 import { DialogContent, DialogOverlay } from '@reach/dialog';
 import '@reach/dialog/styles.css';
-import { Minimize2 } from 'react-feather';
 import styled from 'styled-components';
-
-const CloseChartIcon = styled(Minimize2)`
-  position: absolute;
-  right: 0;
-  color: ${({ theme }) => theme.text2};
-
-  &:hover {
-    color: ${({ theme }) => theme.text1};
-    cursor: pointer;
-  }
-`;
 
 const StyledDialogContent = styled(DialogContent)`
   &[data-reach-dialog-content] {
@@ -28,6 +16,10 @@ const StyledDialogContent = styled(DialogContent)`
     backdrop-filter: blur(25px);
     padding: 1.25rem;
     outline: none;
+
+    @media screen and (max-width: 1080px) {
+      width: 80vw;
+    }
   }
 `;
 
@@ -46,4 +38,4 @@ const Wrapper = styled.div`
   position: relative;
 `;
 
-export { CloseChartIcon, StyledDialogContent, StyledDialogOverlay, Wrapper };
+export { StyledDialogContent, StyledDialogOverlay, Wrapper };

--- a/src/components/NetworkDataCardWithDialog/index.tsx
+++ b/src/components/NetworkDataCardWithDialog/index.tsx
@@ -18,6 +18,9 @@ interface NetworkDataCardWithDialogProps {
   icon: React.ReactNode;
   networksValues: NetworksValue[];
   historicalDataHook: any;
+  defaultTimeFilter: '1M' | '3M' | '1Y';
+  isTimeFilterVisible: boolean;
+  formatActiveDate: any;
 }
 
 const NetworkDataCardWithDialog = ({
@@ -26,6 +29,9 @@ const NetworkDataCardWithDialog = ({
   icon,
   networksValues,
   historicalDataHook,
+  defaultTimeFilter = '1M',
+  isTimeFilterVisible = true,
+  formatActiveDate = null,
 }: NetworkDataCardWithDialogProps) => {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
 
@@ -58,6 +64,9 @@ const NetworkDataCardWithDialog = ({
           title={chartTitle}
           historicalDataHook={historicalDataHook}
           isOpen={isDialogOpen}
+          isTimeFilterVisible={isTimeFilterVisible}
+          defaultTimeFilter={defaultTimeFilter}
+          formatActiveDate={formatActiveDate}
           onClose={toggleDialog}
         />
       )}

--- a/src/components/SideNav/styled.jsx
+++ b/src/components/SideNav/styled.jsx
@@ -5,7 +5,7 @@ import { Typography } from '../../Theme';
 import { MobileMenu } from './MobileMenu';
 
 const Wrapper = styled.div`
-  height: ${({ isMobile }) => (isMobile ? 'initial' : 'calc(100vh - 36px)')};
+  height: ${({ isMobile }) => (isMobile ? 'initial' : '100vh')};
   padding: 0 14px;
   color: ${({ theme }) => theme.text1};
   position: sticky;

--- a/src/components/StackedChart/Header/index.jsx
+++ b/src/components/StackedChart/Header/index.jsx
@@ -11,6 +11,7 @@ const Header = ({
   title,
   value,
   dailyChange,
+  formatActiveDate,
   date,
   filterOptions,
   activeFilter,
@@ -32,7 +33,9 @@ const Header = ({
           </Typography.LargeBoldHeader>
         </Flex>
         <Flex alignItems={'center'} style={{ gap: '6px' }}>
-          <Typography.Text color={'text7'}>{formatChartDate(date, false, isBelow500px)}</Typography.Text>
+          <Typography.Text color={'text7'}>
+            {formatChartDate(date, false, isBelow500px, formatActiveDate)}
+          </Typography.Text>
           <DailyChange>{dailyChange}</DailyChange>
         </Flex>
       </div>
@@ -49,6 +52,7 @@ Header.propTypes = {
   title: PropTypes.string,
   dailyChange: PropTypes.any,
   value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  formatActiveDate: PropTypes.func,
   date: PropTypes.string,
   filterOptions: PropTypes.object,
   activeFilter: PropTypes.string,

--- a/src/components/StackedChart/index.jsx
+++ b/src/components/StackedChart/index.jsx
@@ -1,4 +1,3 @@
-import dayjs from 'dayjs';
 import PropTypes from 'prop-types';
 import { useCallback, useEffect, useState } from 'react';
 import { Flex } from 'rebass';
@@ -28,11 +27,11 @@ const renderLegend = (props) => {
   );
 };
 
-const StackedChart = ({ title, type, data, dataType, showTimeFilter }) => {
+const StackedChart = ({ title, type, data, dataType, defaultTimeFilter, showTimeFilter, formatActiveDate }) => {
   const [filteredData, setFilteredData] = useState(data);
   const [stackedDataValue, setStackedDataValue] = useState(null);
   const [activeDate, setActiveDate] = useState(null);
-  const [activeFilter, setActiveFilter] = useState(STACKED_CHART_TIME_FILTER_OPTIONS.MONTH_1);
+  const [activeFilter, setActiveFilter] = useState(defaultTimeFilter);
   const [dailyChange, setDailyChange] = useState();
 
   // set header values to the latest point of the chart
@@ -146,7 +145,8 @@ const StackedChart = ({ title, type, data, dataType, showTimeFilter }) => {
         dataType={dataType}
         showTimeFilter={showTimeFilter}
         dailyChange={formattedPercent(dailyChange)}
-        date={dayjs(activeDate).format('MMMM D, YYYY')}
+        formatActiveDate={formatActiveDate}
+        date={activeDate}
         activeFilter={activeFilter}
         filterOptions={STACKED_CHART_TIME_FILTER_OPTIONS}
         onFilterChange={setActiveFilter}
@@ -278,13 +278,16 @@ StackedChart.propTypes = {
   data: PropTypes.any.isRequired,
   dataType: PropTypes.oneOf(['CURRENCY', 'PERCENTAGE', 'BASE']),
   showTimeFilter: PropTypes.bool,
+  defaultTimeFilter: PropTypes.oneOf(['1M', '3M', '1Y']),
   type: PropTypes.oneOf(['BAR', 'AREA']).isRequired,
+  formatActiveDate: PropTypes.func,
 };
 
 StackedChart.defaultProps = {
   type: 'AREA',
   data: [],
   dataType: 'CURRENCY',
+  defaultTimeFilter: '1M',
   showTimeFilter: true,
 };
 

--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -18,19 +18,23 @@ import LocalLoader from '../components/LocalLoader';
 import NetworkDataCardWithDialog from '../components/NetworkDataCardWithDialog';
 import Panel from '../components/Panel';
 import StackedChart from '../components/StackedChart';
-import { SupportedNetwork, NETOWRK_FEE_RECEIVER_ADDRESSES } from '../constants';
+import { SupportedNetwork, NETOWRK_FEE_RECEIVER_ADDRESSES, STACKED_CHART_TIME_FILTER_OPTIONS } from '../constants';
 import {
   useDashboardChartData,
   useDashboardComulativeData,
   useOneDaySwapsData,
-  useOneDayWalletsData,
-  usePastMonthWalletsData,
+  usePastYearUniqueDailyWalletsData,
   useSwapsData,
   useUncollectedFeesData,
+  useUniqueDailyWalletsData,
+  useUniqueWeeklyWalletsData,
+  usePastYearUniqueWeeklyWalletsData,
+  useUniqueMonthlyWalletsData,
+  usePastYearUniqueMonthlyWalletsData,
 } from '../contexts/Dashboard';
 import { useSelectedNetworkUpdater } from '../contexts/Network';
 import { useIsBelowPx } from '../hooks/useIsBelowPx';
-import { formattedNum } from '../utils';
+import { formattedNum, getWeekFormattedDate } from '../utils';
 
 const GridRow = styled.div`
   display: grid;
@@ -68,7 +72,9 @@ const CardLoaderWrapper = ({ isLoading, children }) => (
 
 const DashboardPage = ({ history }) => {
   const oneDayTransactions = useOneDaySwapsData();
-  const oneDayWalletsData = useOneDayWalletsData();
+  const oneDayWalletsData = useUniqueDailyWalletsData(dayjs.utc().startOf('day').unix());
+  const oneWeekWalletsData = useUniqueWeeklyWalletsData(dayjs.utc().subtract(7, 'day').startOf('day').unix());
+  const oneMonthWalletsData = useUniqueMonthlyWalletsData(dayjs.utc().subtract(1, 'month').startOf('day').unix());
   const chartData = useDashboardChartData();
   const comulativeData = useDashboardComulativeData();
   const switchNetwork = useSelectedNetworkUpdater();
@@ -158,6 +164,8 @@ const DashboardPage = ({ history }) => {
     formattedComulativeData.trades.length === 0 || formattedComulativeData.volume.length === 0;
   const isLoadingOneDayTransactions = oneDayTransactions === undefined || Object.keys(oneDayTransactions).length === 0;
   const isLoadingOneDayWallets = oneDayWalletsData === undefined || Object.keys(oneDayWalletsData).length === 0;
+  const isLoadingOneWeekWallets = oneWeekWalletsData === undefined || Object.keys(oneWeekWalletsData).length === 0;
+  const isLoadingOneMonthWallets = oneMonthWalletsData === undefined || Object.keys(oneMonthWalletsData).length === 0;
 
   return (
     <PageWrapper>
@@ -219,10 +227,32 @@ const DashboardPage = ({ history }) => {
                 <CardLoaderWrapper isLoading={isLoadingOneDayWallets}>
                   <NetworkDataCardWithDialog
                     title={'Daily wallets'}
-                    chartTitle={'Wallets'}
+                    chartTitle={'Daily Wallets'}
                     icon={<Icon icon={<WalletsSvg height={18} width={18} />} />}
                     networksValues={oneDayWalletsData}
-                    historicalDataHook={usePastMonthWalletsData}
+                    historicalDataHook={usePastYearUniqueDailyWalletsData}
+                  />
+                </CardLoaderWrapper>
+                <CardLoaderWrapper isLoading={isLoadingOneWeekWallets}>
+                  <NetworkDataCardWithDialog
+                    title={'Weekly wallets'}
+                    chartTitle={'Weekly Wallets'}
+                    icon={<Icon icon={<WalletsSvg height={18} width={18} />} />}
+                    networksValues={oneWeekWalletsData}
+                    formatActiveDate={(activeDate) => getWeekFormattedDate(activeDate, true)}
+                    historicalDataHook={usePastYearUniqueWeeklyWalletsData}
+                  />
+                </CardLoaderWrapper>
+                <CardLoaderWrapper isLoading={isLoadingOneMonthWallets}>
+                  <NetworkDataCardWithDialog
+                    title={'Monthly wallets'}
+                    chartTitle={'Monthly Wallets'}
+                    icon={<Icon icon={<WalletsSvg height={18} width={18} />} />}
+                    networksValues={oneMonthWalletsData}
+                    isTimeFilterVisible={false}
+                    defaultTimeFilter={STACKED_CHART_TIME_FILTER_OPTIONS.YEAR}
+                    formatActiveDate={(activeDate) => dayjs(activeDate).format('MMMM YYYY')}
+                    historicalDataHook={usePastYearUniqueMonthlyWalletsData}
                   />
                 </CardLoaderWrapper>
               </AutoColumn>
@@ -278,10 +308,32 @@ const DashboardPage = ({ history }) => {
                   <CardLoaderWrapper isLoading={isLoadingOneDayWallets}>
                     <NetworkDataCardWithDialog
                       title={'Daily wallets'}
-                      chartTitle={'Wallets'}
+                      chartTitle={'Past Year Daily Wallets'}
                       icon={<Icon icon={<WalletsSvg height={18} width={18} />} />}
                       networksValues={oneDayWalletsData}
-                      historicalDataHook={usePastMonthWalletsData}
+                      historicalDataHook={usePastYearUniqueDailyWalletsData}
+                    />
+                  </CardLoaderWrapper>
+                  <CardLoaderWrapper isLoading={isLoadingOneWeekWallets}>
+                    <NetworkDataCardWithDialog
+                      title={'Weekly wallets'}
+                      chartTitle={'Past Year Weekly Wallets'}
+                      icon={<Icon icon={<WalletsSvg height={18} width={18} />} />}
+                      networksValues={oneWeekWalletsData}
+                      formatActiveDate={(activeDate) => getWeekFormattedDate(activeDate)}
+                      historicalDataHook={usePastYearUniqueWeeklyWalletsData}
+                    />
+                  </CardLoaderWrapper>
+                  <CardLoaderWrapper isLoading={isLoadingOneMonthWallets}>
+                    <NetworkDataCardWithDialog
+                      title={'Monthly wallets'}
+                      chartTitle={'Past Year Monthly Wallets'}
+                      icon={<Icon icon={<WalletsSvg height={18} width={18} />} />}
+                      networksValues={oneMonthWalletsData}
+                      isTimeFilterVisible={false}
+                      defaultTimeFilter={STACKED_CHART_TIME_FILTER_OPTIONS.YEAR}
+                      formatActiveDate={(activeDate) => dayjs(activeDate).format('MMMM YYYY')}
+                      historicalDataHook={usePastYearUniqueMonthlyWalletsData}
                     />
                   </CardLoaderWrapper>
                 </GridCard>

--- a/src/utils/index.jsx
+++ b/src/utils/index.jsx
@@ -830,7 +830,7 @@ export function formatChartValueByType(value, dataType, short) {
     return formattedNum(value) + '%';
   }
 
-  return value;
+  return formattedNum(value);
 }
 
 /**
@@ -853,7 +853,11 @@ export function getWeekFormattedDate(date, short) {
     .format(short ? 'MMM D, YY' : 'MMMM D, YYYY')}`;
 }
 
-export function formatChartDate(date, isWeekly, short) {
+export function formatChartDate(date, isWeekly, short, formatActiveDate = null) {
+  if (formatActiveDate) {
+    return formatActiveDate(date);
+  }
+
   return isWeekly ? getWeekFormattedDate(date, short) : dayjs(date).format(short ? 'MMM D, YY' : 'MMMM D, YYYY');
 }
 


### PR DESCRIPTION
Fixes #94.

These changes optimize the existing charts regarding `trades` and `unique daily wallets`, and add new ones about `unique weekly wallets` and `monthly unique wallets`.

This PR can't be merged yet, it needs to wait for the Gnosis subgraph to fully sync in order to fetch the updated Gnosis data https://thegraph.com/hosted-service/subgraph/dxgraphs/swapr-xdai-v2?version=pending; the subgraph is currently having syncing issues causing it to slow down (The Graph team is aware of this issue and they reported it to Gnosis, since it's an RPC related problem).

Detailed changes:

- [x] `Trades 24h` chart now fetches 1 year of historical data in about 5s, while before it took more than 2 mins to fetch 1 month of data.
- [x] `Daily wallets` chart now fetches 1 year of historical data in about 5s, while before it took more than 2 mins to fetch 1 month of data.
- [x] Add the new `Weekly wallets` card and chart that displays weekly unique interactions (1 year historical data).
- [x] Add the new `Monthly wallets` card and chart that displays monthly unique interactions (1 year historical data). 
- [x] Charts in dialogs now have the time filter since there's one year of data.

![image](https://user-images.githubusercontent.com/9011637/198387650-d3362cda-9017-4d25-b3b0-025f2c55d1ad.png)

https://user-images.githubusercontent.com/9011637/198388374-09d58595-da22-4bb9-b161-d49a877da9f5.mp4

